### PR TITLE
Fix mirrored RTL layout on native builds

### DIFF
--- a/www/app/_layout.tsx
+++ b/www/app/_layout.tsx
@@ -16,9 +16,13 @@ import { ConsentBanner } from '../src/components/ConsentBanner';
 
 const appIcon = require('../assets/images/app-icon.png');
 
-// Force RTL layout for Arabic
-I18nManager.allowRTL(true);
-I18nManager.forceRTL(true);
+// RTL is hand-built everywhere via `flexDirection: 'row-reverse'`/textAlign,
+// same as on web (where RNW's I18nManager is a no-op, isRTL always false).
+// Forcing native RTL here made Yoga auto-mirror those rows a second time —
+// keep layout direction LTR so native matches web. (Needs one full native
+// restart on a device that previously had RTL forced, not just Fast Refresh.)
+I18nManager.allowRTL(false);
+I18nManager.forceRTL(false);
 
 // Apply Amiri as the app-wide default font (web only — the Amiri woff2 face is
 // loaded via expo-font for web; native keeps the system Arabic font, as before).


### PR DESCRIPTION
## Summary
- Native builds showed the entire app mirrored left-right versus the web version (avatar/greeting row, stat card order, warning-banner icon/chevron placement, bottom tab bar order all flipped).
- Root cause: the whole app's RTL look is hand-built via explicit `flexDirection: 'row-reverse'` / `textAlign: 'right'` styling, matching how it renders on web (`react-native-web`'s `I18nManager` is a permanent no-op — `isRTL` is hardcoded `false`, so RNW never auto-mirrors flex layouts).
- On native, `I18nManager.forceRTL(true)` was also being called, which makes Yoga automatically mirror `row`/`row-reverse` a second time whenever `isRTL` is true — flipping the already-manually-reversed layout back to a visual LTR order. That double-mirroring is exactly what the screenshots showed.
- Fix: force native's layout direction to stay LTR (`allowRTL(false)` / `forceRTL(false)`) so it matches web's effective behavior, letting the existing manual row-reverse/textAlign styling render identically on both platforms regardless of device locale.

## Test plan
- [x] `npx tsc --noEmit` passes.
- [ ] On a device/emulator that previously had RTL forced, fully force-stop and relaunch the app (a plain JS reload isn't enough — `I18nManager` persists its flag natively and is only re-read on a fresh bridge/process start) and confirm the me/home screen, stat cards, review banner, and bottom tab bar now match the web layout (home tab on the right, stat cards in the same right-to-left order, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)