### PR TITLE
Fix net.quranquiz package identifier, prep Android release build

### DIFF
--- a/www/GoogleService-Info.plist
+++ b/www/GoogleService-Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>635224907527-a7odhljomvqdbq4k26l45st7jhej7mir.apps.googleusercontent.com</string>
+	<string>635224907527-h6m6o8kqoud1bcroammqlf97ip6t41lt.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.635224907527-a7odhljomvqdbq4k26l45st7jhej7mir</string>
+	<string>com.googleusercontent.apps.635224907527-h6m6o8kqoud1bcroammqlf97ip6t41lt</string>
 	<key>ANDROID_CLIENT_ID</key>
-	<string>635224907527-65a5t9ddg7dk1grglanf51jbiljvoq68.apps.googleusercontent.com</string>
+	<string>635224907527-bqg6h4e8cpel7l9q14n2b084f71hch24.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
 	<string>AIzaSyD7B4uSmrN2o8iqI-akW0te2RPIs8GQNO0</string>
 	<key>GCM_SENDER_ID</key>
@@ -15,7 +15,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>net.quranquiz.app</string>
+	<string>net.quranquiz</string>
 	<key>PROJECT_ID</key>
 	<string>quranquiznet-3a54c</string>
 	<key>STORAGE_BUCKET</key>
@@ -31,7 +31,7 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:635224907527:ios:dcf412b554094e663a6fa2</string>
+	<string>1:635224907527:ios:666bbf18bbc26f143a6fa2</string>
 	<key>DATABASE_URL</key>
 	<string>https://quranquiznet-3a54c.firebaseio.com</string>
 </dict>

--- a/www/app.config.js
+++ b/www/app.config.js
@@ -78,7 +78,7 @@ module.exports = ({ config }) => {
             // iOS reversed-client-id scheme.
             CFBundleURLSchemes: [
               'quranquiz',
-              'net.quranquiz.app',
+              'net.quranquiz',
               ...(facebookScheme ? [facebookScheme] : []),
               ...googleIosScheme,
             ],

--- a/www/app.json
+++ b/www/app.json
@@ -14,14 +14,15 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "net.quranquiz.app"
+      "bundleIdentifier": "net.quranquiz"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/app-icon.png",
         "backgroundColor": "#1a5276"
       },
-      "package": "net.quranquiz.app"
+      "package": "net.quranquiz",
+      "versionCode": 10
     },
     "web": {
       "bundler": "metro",
@@ -38,7 +39,15 @@
           ]
         }
       ],
-      "expo-notifications"
+      "expo-notifications",
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "targetSdkVersion": 35
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/www/google-services.json
+++ b/www/google-services.json
@@ -23,6 +23,14 @@
           }
         },
         {
+          "client_id": "635224907527-j1ol65029be0o8vmmpf3ti6qctgifgrb.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "net.quranquiz",
+            "certificate_hash": "5e8f16062ea3cd2c4a0d547876baa6f38cabf625"
+          }
+        },
+        {
           "client_id": "635224907527-bdic77p58a8tjkeuj96csup7tnoe870s.apps.googleusercontent.com",
           "client_type": 3
         }

--- a/www/google-services.json
+++ b/www/google-services.json
@@ -8,18 +8,18 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:635224907527:android:a2c61483d8332eaa3a6fa2",
+        "mobilesdk_app_id": "1:635224907527:android:b30131b4f6b991fd3a6fa2",
         "android_client_info": {
-          "package_name": "net.quranquiz.app"
+          "package_name": "net.quranquiz"
         }
       },
       "oauth_client": [
         {
-          "client_id": "635224907527-65a5t9ddg7dk1grglanf51jbiljvoq68.apps.googleusercontent.com",
+          "client_id": "635224907527-bqg6h4e8cpel7l9q14n2b084f71hch24.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "net.quranquiz.app",
-            "certificate_hash": "86303f71782642a20fd63cd58dbe1c277bf215ee"
+            "package_name": "net.quranquiz",
+            "certificate_hash": "2a78f67e22a445d32a6ceb20cfda6db8e6d93981"
           }
         },
         {

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quranquiznet",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quranquiznet",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "dependencies": {
         "@expo/vector-icons": "~14.0.4",
         "@react-native-async-storage/async-storage": "1.23.1",
@@ -15,6 +15,7 @@
         "expo-asset": "~11.0.5",
         "expo-auth-session": "~6.0.3",
         "expo-av": "~15.0.2",
+        "expo-build-properties": "~0.13.3",
         "expo-crypto": "~14.0.2",
         "expo-file-system": "~18.0.12",
         "expo-font": "~13.0.4",
@@ -9981,6 +9982,53 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.13.3.tgz",
+      "integrity": "sha512-gw7AYP+YF50Gr912BedelRDTfR4GnUEn9p5s25g4nv0hTJGWpBZdCYR5/Oi2rmCHJXxBqhPjxzV7JRh72fntLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-constants": {

--- a/www/package.json
+++ b/www/package.json
@@ -21,6 +21,7 @@
     "expo-asset": "~11.0.5",
     "expo-auth-session": "~6.0.3",
     "expo-av": "~15.0.2",
+    "expo-build-properties": "~0.13.3",
     "expo-crypto": "~14.0.2",
     "expo-file-system": "~18.0.12",
     "expo-font": "~13.0.4",

--- a/www/src/services/nativeOAuth.ts
+++ b/www/src/services/nativeOAuth.ts
@@ -62,7 +62,7 @@ function googleClientId(): string | undefined {
 
 /**
  * The native Google flow redirects to the app's own package/bundle-id scheme
- * (e.g. `net.quranquiz.app:/oauthredirect`). Google binds the iOS/Android OAuth
+ * (e.g. `net.quranquiz:/oauthredirect`). Google binds the iOS/Android OAuth
  * client to that identifier, so it accepts this redirect and rejects any other
  * (including the reversed client-id scheme) with `invalid_request`. The scheme is
  * registered by default from the applicationId, so no extra config is needed.
@@ -72,7 +72,7 @@ function googleRedirectUri(): string {
   const cfg = Constants.expoConfig;
   const appId =
     (Platform.OS === 'ios' ? cfg?.ios?.bundleIdentifier : cfg?.android?.package) ??
-    'net.quranquiz.app';
+    'net.quranquiz';
   return AuthSession.makeRedirectUri({ native: `${appId}:/oauthredirect` });
 }
 


### PR DESCRIPTION
## Summary
- The React Native rewrite had accidentally set the Android/iOS package identifier to `net.quranquiz.app`, but the live Play Store listing (343 installs, since 2015) and the app's Firebase project use `net.quranquiz`. This reverts `app.json`, the iOS URL scheme in `app.config.js`, and the native OAuth redirect fallback back to `net.quranquiz`.
- Registers matching Firebase Android/iOS apps for `net.quranquiz` and updates `google-services.json` / `GoogleService-Info.plist` accordingly (the old `.app`-suffixed Firebase apps have since been deleted by the developer).
- Adds `expo-build-properties` to durably pin `targetSdkVersion=35` (current Play Store requirement) across `expo prebuild --clean` regenerations.
- Sets an explicit `android.versionCode: 10` in `app.json` (durable across prebuild), ahead of the live release's versionCode `9`.

## Release build
A release AAB (`versionCode 10`, `versionName 2.1.7`) was built locally with `./gradlew bundleRelease`, signed with the original 2013 upload key recovered by the developer. The signing certificate on the built AAB was verified to exactly match the certificate currently signing the live Play Store app (SHA1 `2A:78:F6:7E:22:A4:45:D3:2A:6C:EB:20:CF:DA:6D:B8:E6:D9:39:81`), confirming it can be uploaded as a valid update to the existing listing.

Note: `android/` and `ios/` are gitignored (CNG-regenerated), so the release `signingConfig` wired into `android/app/build.gradle` for this build lives only locally and reads credentials from `~/.gradle/gradle.properties` (outside the repo). It will need to be re-applied after any future `expo prebuild --clean`.

## Test plan
- [ ] `npx tsc --noEmit`
- [ ] `npm test`
- [ ] Confirm Google Sign-In still works on a device build (new OAuth client tied to `net.quranquiz` + the release key's SHA-1)
- [ ] Upload the built AAB to Play Console's Internal Testing track first, verify the app installs/updates cleanly over the existing `net.quranquiz` install base, before promoting to Production

🤖 Generated with [Claude Code](https://claude.com/claude-code)