### PR TITLE
Fix stale-forever cache for self-hosted Quran renderer assets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -44,7 +44,7 @@
       {
         "source": "/quran-madina/**",
         "headers": [
-          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+          { "key": "Cache-Control", "value": "no-cache" }
         ]
       }
     ]

--- a/www/public/sw.js
+++ b/www/public/sw.js
@@ -2,16 +2,20 @@
  *
  * Strategy (full offline after first load):
  *  - Navigations (HTML): network-first, fall back to cached app shell when offline.
- *  - Hashed/immutable assets (/_expo/, /assets/, /icons/, js/css/fonts/images):
- *    cache-first. These names are content-hashed by the Expo export, so once
- *    cached they never go stale — this is what makes the bundled q.json (and the
- *    whole quiz) work fully offline after the first visit.
- *  - Everything else same-origin: network-first with cache fallback.
+ *  - Hashed/immutable assets (/_expo/, /assets/, /icons/): cache-first. These
+ *    paths are content-hashed by the Expo export, so once cached they never go
+ *    stale — this is what makes the bundled q.json (and the whole quiz) work
+ *    fully offline after the first visit.
+ *  - Everything else same-origin (including /quran-madina/, whose filenames are
+ *    NOT content-hashed): network-first with cache fallback, so a content
+ *    update at the same URL (e.g. a quran-madina-html bump) reaches returning
+ *    visitors instead of sticking behind a stale cache-first entry forever.
+ *    Offline still works via the cache fallback.
  *
  * Bump CACHE_VERSION on every release to bust old caches (the React/Expo
  * equivalent of the old www/worker.js `cacheName` bump).
  */
-const CACHE_VERSION = 'v6';
+const CACHE_VERSION = 'v7';
 const CACHE_NAME = `qqn-${CACHE_VERSION}`;
 
 // App-shell resources precached at install time.
@@ -56,12 +60,16 @@ self.addEventListener('message', (event) => {
   if (event.data === 'SKIP_WAITING') self.skipWaiting();
 });
 
+// Path-prefix allowlist, not a file-extension match: only paths the Expo export
+// actually content-hashes belong here. A blanket extension match (e.g. any
+// same-origin .js/.css/.json) would also catch non-hashed static files like
+// /quran-madina/** and cache them first forever, so a content update at that
+// same URL would never reach a returning visitor short of a CACHE_VERSION bump.
 function isImmutableAsset(url) {
   return (
     url.pathname.startsWith('/_expo/') ||
     url.pathname.startsWith('/assets/') ||
-    url.pathname.startsWith('/icons/') ||
-    /\.(js|css|woff2?|ttf|otf|png|jpe?g|gif|svg|webp|ico|json)$/i.test(url.pathname)
+    url.pathname.startsWith('/icons/')
   );
 }
 


### PR DESCRIPTION
## Summary
- `/quran-madina/**` (self-hosted quran-madina-html JS/CSS/font/DB) was marked `Cache-Control: immutable, max-age=31536000` in `firebase.json`, and the service worker's `isImmutableAsset()` also cache-firsted it via a blanket file-extension match — but unlike `/_expo/**` and `/assets/**`, these filenames are **not** content-hashed.
- The July 10 madina bug fix (f49fef4) updated that content at the same URLs, but returning visitors (confirmed: iOS Safari) never saw it — both the browser's HTTP cache and the SW's Cache Storage kept serving pre-fix bytes indefinitely, since nothing signaled the content had changed. Net effect: no Quran text (or the old buggy render) for anyone who'd loaded the site before the fix.
- Fresh sessions were unaffected, which is why this didn't show up in normal testing.

## Fix
- `firebase.json`: `/quran-madina/**` → `Cache-Control: no-cache` (revalidates every time; still fast via 304s).
- `www/public/sw.js`: `isImmutableAsset()` narrowed to a path-prefix allowlist (`/_expo/`, `/assets/`, `/icons/`) instead of matching any same-origin `.js/.css/.json/...` by extension — the extension match is what silently swept in `/quran-madina/**`.
- `CACHE_VERSION` bumped `v6` → `v7` to drop the stale Cache Storage entry for already-affected visitors on next load.

## Test plan
- [x] Validated `firebase.json` JSON syntax and `sw.js` JS syntax.
- [x] Manually exercised the live site pre-fix (dashboard, daily quiz, full Madina-rendered training view) in a fresh browser session — confirmed the bug only reproduces with a pre-existing stale cache, not on fresh load.
- [ ] After deploy: confirm on a previously-affected device (iOS Safari) that a reload now shows correct Quran text.