### PR TITLE
Fix league leaderboard not scrollable on iOS Safari (web)

### DIFF
--- a/www/app/(app)/league.tsx
+++ b/www/app/(app)/league.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState, useCallback } from 'react';
+import { Fragment, useEffect, useState, useCallback } from 'react';
 import {
   View, Text, StyleSheet, ScrollView,
-  ActivityIndicator, Alert, FlatList, Platform,
+  ActivityIndicator, Alert, Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useNavigation } from 'expo-router';
@@ -273,13 +273,15 @@ export default function LeagueScreen() {
                   })}
                 </View>
               )}
-              <FlatList
-                data={rest}
-                keyExtractor={(_, i) => String(i)}
-                renderItem={renderRow}
-                scrollEnabled={false}
-                ItemSeparatorComponent={() => <View style={[s.sep, { backgroundColor: colors.line }]} />}
-              />
+              {/* Plain rows, not a FlatList: a disabled nested list gets
+                  touch-action:none on web, which blocked iOS Safari from
+                  panning the page ScrollView for touches starting on it. */}
+              {rest.map((item, index) => (
+                <Fragment key={index}>
+                  {index > 0 && <View style={[s.sep, { backgroundColor: colors.line }]} />}
+                  {renderRow({ item, index })}
+                </Fragment>
+              ))}
             </>
           )}
         </View>


### PR DESCRIPTION
## Problem
On iOS Safari (web), the league screen would not scroll — top players below the fold were unreachable.

## Root cause
The ranks-4+ leaderboard rows were rendered with a `FlatList scrollEnabled={false}` nested inside the page `ScrollView`. react-native-web implements `scrollEnabled={false}` by styling the element with `touch-action: none` (`ScrollViewBase.js` → `styles.scrollDisabled`). `touch-action: none` forbids the browser from using touches that start on that element to pan *any* ancestor scroller — and since the list covers most of the screen, touch-dragging did nothing. Desktop wheel scrolling was unaffected, which is why the bug only surfaced on touch devices.

## Fix
Render the rows as plain mapped `View`s instead of a FlatList. The list is a static top-10 slice that was already non-scrolling and non-virtualized, so FlatList added nothing — and nesting a VirtualizedList inside a ScrollView is an anti-pattern on native anyway. With no nested scroll container, no `touch-action: none` is emitted and the page ScrollView pans normally.

Same row rendering and separators as before; keys match the old `keyExtractor` (index-based).

## Verification
- `npx tsc --noEmit` — clean
- `npx jest --watchAll=false` — 20 suites, 174 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)