### PR TITLE
fix: study parts list title hidden under iOS status bar

### DIFF
--- a/www/app/(app)/map.tsx
+++ b/www/app/(app)/map.tsx
@@ -133,7 +133,7 @@ export default function MapScreen() {
   const activeParts = profile.parts.filter((p) => p.checked).length;
 
   return (
-    <SafeAreaView style={[s.container, { backgroundColor: colors.paper }]} edges={['bottom']}>
+    <SafeAreaView style={[s.container, { backgroundColor: colors.paper }]} edges={['top', 'bottom']}>
       <View style={[s.header, { borderColor: colors.line, flexDirection: rowDir(isRTL) }]}>
         <PressScale onPress={() => router.back()} hitSlop={10} style={s.backBtn}>
           <Ionicons name={mirror(isRTL, 'chevron-back', 'chevron-forward')} size={22} color={colors.ink} />


### PR DESCRIPTION
## Summary
- `www/app/(app)/map.tsx` (the study-parts / memorization-map list) draws its own in-page header instead of using the native tab header, but its `SafeAreaView` only reserved the `bottom` edge.
- On iOS, the title rendered underneath the status bar / WiFi icon / Dynamic Island.
- Fix: reserve `top` as well (`edges={['top', 'bottom']}`), matching the same pattern already used by the auth screens that also render their own custom headers (`(auth)/index.tsx`, `(auth)/privacy.tsx`, `(auth)/support.tsx`).
- Scoped to only this screen — other tab screens (`me`, `quiz`, `league`, `pvp`, `settings`) keep the native header and were unaffected.

## Test plan
- [ ] Build/run on an iOS device or simulator with a Dynamic Island (e.g. iPhone 15/16), open the study-parts (memorization map) screen, confirm the title clears the status bar/notch.
- [ ] Spot-check web + Android are unchanged (no top notch there, `edges: ['top','bottom']` is a no-op when there's no top inset).