### PR TITLE
chore: bump iOS build number to 8

### DIFF
--- a/www/app.json
+++ b/www/app.json
@@ -10,7 +10,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "net.quranquiz",
-      "buildNumber": "7",
+      "buildNumber": "8",
       "appleTeamId": "FNSP52WBLF",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false


### PR DESCRIPTION
## Summary
- Bump `www/app.json` iOS `buildNumber` from 7 to 8 ahead of a new EAS build.

## Test plan
- [ ] EAS iOS build succeeds and installs on device/TestFlight