### PR TITLE
Split rank + PvP progress bars into sections with their driving action

### DIFF
--- a/www/app/(app)/me.tsx
+++ b/www/app/(app)/me.tsx
@@ -19,7 +19,7 @@ import { Avatar } from '../../src/components/Avatar';
 import { scheduleDailyReminder } from '../../src/services/notifications';
 import { describeLiveRank } from '../../src/models/dailyRank';
 import { getRankInfo, getRankLadder } from '../../src/models/rank';
-import { getPvpTierInfo } from '../../src/models/pvpTiers';
+import { getPvpTierInfo, PVP_TIER_COLOR } from '../../src/models/pvpTiers';
 import { useTheme, arNum, localeNum, radii } from '../../src/theme/tokens';
 import { useDirection, rowDir, alignDir, mirror } from '../../src/theme/direction';
 import PressScale from '../../src/components/PressScale';
@@ -475,43 +475,8 @@ export default function MeScreen() {
 
   const avatarUri = social.photoURL && !avatarError ? social.photoURL : undefined;
 
-  // "Ways to play" — quick play + PvP as a 2-up row, with the weak-sura nudge
-  // folded in as a third option, instead of three competing full-width blocks.
-  const waysToPlay = (
-    <View style={s.waysWrap}>
-      <View style={[s.waysRow, { flexDirection: rowDir(isRTL) }]}>
-        <PressScale
-          style={[s.wayTile, { backgroundColor: colors.navy }]}
-          onPress={() => router.push({ pathname: '/(app)/quiz', params: { chooser: '1', nonce: String(Date.now()) } })}
-        >
-          <Ionicons name="play" size={22} color="#fff" />
-          <Text style={s.wayTileTxt}>{t('quiz.startQuiz')}</Text>
-        </PressScale>
-        <PressScale
-          style={[s.wayTile, { backgroundColor: colors.card, borderWidth: 1.5, borderColor: colors.gold }]}
-          onPress={() => router.push('/(app)/pvp')}
-        >
-          <Ionicons name="flash" size={22} color={colors.goldDeep} />
-          <Text style={[s.wayTileTxt, { color: colors.goldDeep }]}>{t('pvp.idleTitle')}</Text>
-          {pvpTotal > 0 && (
-            <View style={[s.wayBadge, { backgroundColor: colors.goldPale, [isRTL ? 'left' : 'right']: 8 }]}>
-              <Text style={[s.wayBadgeTxt, { color: colors.goldDeep }]}>{t('me.pvpWinsBadge', { count: localeNum(profile.pvp.wins, lang) })}</Text>
-            </View>
-          )}
-        </PressScale>
-      </View>
-      {weakPartIndex >= 0 && (
-        <PressScale
-          style={[s.wayNudge, { backgroundColor: colors.goldPale, flexDirection: rowDir(isRTL) }]}
-          onPress={() => router.push({ pathname: '/(app)/quiz', params: { customPart: String(weakPartIndex), nonce: String(Date.now()) } })}
-        >
-          <Ionicons name={mirror(isRTL, 'chevron-forward', 'chevron-back')} size={16} color={colors.goldDeep} />
-          <Text style={[s.wayNudgeTxt, { color: colors.goldDeep, textAlign: alignDir(isRTL) }]}>{t('me.weakSuraNudge', { sura: translatePartName(weakSura) })}</Text>
-          <Ionicons name="warning" size={15} color={colors.goldDeep} />
-        </PressScale>
-      )}
-    </View>
-  );
+  const startQuiz = () => router.push({ pathname: '/(app)/quiz', params: { chooser: '1', nonce: String(Date.now()) } });
+  const startPvp = () => router.push('/(app)/pvp');
 
   return (
     <SafeAreaView style={[s.container, { backgroundColor: colors.paper }]} edges={['bottom']}>
@@ -563,12 +528,14 @@ export default function MeScreen() {
           </PressScale>
         </View>
 
-        {/* ── Give the score a destination: badge + rank title + progress to
-            next rank — tap opens the full ladder (all ranks + how to reach
-            each one). Same badge icon set as the ladder sheet, so the current
-            rank reads as one continuous idea between the two. ── */}
-        <PressScale style={[s.bentoFull, s.rankCard, { backgroundColor: colors.card }]} onPress={() => setRankSheetOpen(true)}>
-          <View style={[s.rankHeaderRow, { flexDirection: rowDir(isRTL) }]}>
+        {/* ── Study rank section: a heading names the system, the bar shows
+            where the score sits (tap opens the full ladder), and the action
+            row is the one thing that actually moves this specific bar —
+            answering quiz questions — so the driving action sits right under
+            the progress it drives instead of in a separate generic row. ── */}
+        <View style={[s.bentoFull, s.progressSection, { backgroundColor: colors.card }]}>
+          <Text style={[s.sectionLabel, { color: colors.inkSoft, textAlign: alignDir(isRTL) }]}>{t('me.rankSheet.title')}</Text>
+          <PressScale style={[s.rankHeaderRow, { flexDirection: rowDir(isRTL) }]} onPress={() => setRankSheetOpen(true)}>
             <View style={[s.rankBadgeSmall, { backgroundColor: colors.gold }]}>
               <Ionicons name={RANK_ICONS[rank.index]} size={18} color={colors.navy} />
             </View>
@@ -588,14 +555,30 @@ export default function MeScreen() {
                 <View style={[s.rankFill, { width: `${rank.progress * 100}%`, backgroundColor: colors.gold, [isRTL ? 'right' : 'left']: 0 }]} />
               </View>
             </View>
-          </View>
-        </PressScale>
+          </PressScale>
+          <PressScale style={[s.sectionActionBtn, { backgroundColor: colors.navy, flexDirection: rowDir(isRTL) }]} onPress={startQuiz}>
+            <Ionicons name="play" size={18} color="#fff" />
+            <Text style={s.sectionActionTxt}>{t('quiz.startQuiz')}</Text>
+          </PressScale>
+          {weakPartIndex >= 0 && (
+            <PressScale
+              style={[s.wayNudge, { backgroundColor: colors.goldPale, flexDirection: rowDir(isRTL) }]}
+              onPress={() => router.push({ pathname: '/(app)/quiz', params: { customPart: String(weakPartIndex), nonce: String(Date.now()) } })}
+            >
+              <Ionicons name={mirror(isRTL, 'chevron-forward', 'chevron-back')} size={16} color={colors.goldDeep} />
+              <Text style={[s.wayNudgeTxt, { color: colors.goldDeep, textAlign: alignDir(isRTL) }]}>{t('me.weakSuraNudge', { sura: translatePartName(weakSura) })}</Text>
+              <Ionicons name="warning" size={15} color={colors.goldDeep} />
+            </PressScale>
+          )}
+        </View>
 
-        {/* ── PvP journey: the world-map counterpart of the rank card above —
-            city name + tier badge instead of a score title, tap opens the
-            full-screen map instead of a sheet (a map deserves the room). ── */}
-        <PressScale style={[s.bentoFull, s.rankCard, { backgroundColor: colors.card }]} onPress={() => router.push('/(app)/pvp-journey')}>
-          <View style={[s.rankHeaderRow, { flexDirection: rowDir(isRTL) }]}>
+        {/* ── PvP journey section: same shape as the study section above, but
+            its own tier color (not the shared rank gold) and its own action
+            — starting a live 1v1 match, the only thing that moves this bar —
+            so the two sections read as separate systems instead of twins. ── */}
+        <View style={[s.bentoFull, s.progressSection, { backgroundColor: colors.card }]}>
+          <Text style={[s.sectionLabel, { color: colors.inkSoft, textAlign: alignDir(isRTL) }]}>{t('pvpJourney.title')}</Text>
+          <PressScale style={[s.rankHeaderRow, { flexDirection: rowDir(isRTL) }]} onPress={() => router.push('/(app)/pvp-journey')}>
             <View style={[s.rankBadgeSmall, { backgroundColor: colors.goldPale }]}>
               <Text style={{ fontSize: 18 }}>{TIER_EMOJI[pvpTier.tier]}</Text>
             </View>
@@ -610,11 +593,23 @@ export default function MeScreen() {
                 </Text>
               </View>
               <View style={[s.rankTrack, { backgroundColor: colors.goldPale }]}>
-                <View style={[s.rankFill, { width: `${pvpTier.progress * 100}%`, backgroundColor: colors.gold, [isRTL ? 'right' : 'left']: 0 }]} />
+                <View style={[s.rankFill, { width: `${pvpTier.progress * 100}%`, backgroundColor: PVP_TIER_COLOR[pvpTier.tier], [isRTL ? 'right' : 'left']: 0 }]} />
               </View>
             </View>
-          </View>
-        </PressScale>
+          </PressScale>
+          <PressScale
+            style={[s.sectionActionBtn, { backgroundColor: colors.card, borderWidth: 1.5, borderColor: colors.gold, flexDirection: rowDir(isRTL) }]}
+            onPress={startPvp}
+          >
+            <Ionicons name="flash" size={18} color={colors.goldDeep} />
+            <Text style={[s.sectionActionTxt, { color: colors.goldDeep }]}>{t('pvp.idleTitle')}</Text>
+            {pvpTotal > 0 && (
+              <View style={[s.sectionBadge, { backgroundColor: colors.goldPale }]}>
+                <Text style={[s.wayBadgeTxt, { color: colors.goldDeep }]}>{t('me.pvpWinsBadge', { count: localeNum(profile.pvp.wins, lang) })}</Text>
+              </View>
+            )}
+          </PressScale>
+        </View>
 
         {/* ── One hero at a time: the daily card until completed ── */}
         {dailyHead === 'loading' ? (
@@ -656,9 +651,6 @@ export default function MeScreen() {
             </View>
           </View>
         )}
-
-        {/* ── Ways to play — promoted once the daily is done, present either way ── */}
-        {waysToPlay}
 
         {/* ── BENTO: 2× progress ring tiles + sparkline ── */}
         <View style={[s.bentoRow, { flexDirection: rowDir(isRTL) }]}>
@@ -826,8 +818,10 @@ const s = StyleSheet.create({
   bentoRow: { gap: 12 },
   bentoHalf: { flex: 1, borderRadius: radii.lg, ...CARD_SHADOW },
 
-  // Rank card
-  rankCard: { padding: 14 },
+  // Progress section wrapper — pairs a labeled progress bar with the one
+  // action that actually drives it (study rank / PvP journey each get one).
+  progressSection: { padding: 14, gap: 12 },
+  sectionLabel: { fontSize: 12, fontFamily: 'PlexArabic-Bold' },
   rankHeaderRow: { alignItems: 'flex-start', gap: 10 },
   rankBadgeSmall: { width: 34, height: 34, borderRadius: 17, alignItems: 'center', justifyContent: 'center' },
   rankColumn: { flex: 1, gap: 8 },
@@ -878,19 +872,13 @@ const s = StyleSheet.create({
   dailyUnavailTxt: { fontSize: 14, fontFamily: 'PlexArabic-SemiBold' },
   dailyUnavailSub: { fontSize: 12, marginTop: 2 },
 
-  // Ways to play
-  waysWrap: { gap: 8 },
-  waysRow: { gap: 10 },
-  wayTile: {
-    flex: 1,
-    borderRadius: radii.lg,
-    paddingVertical: 18,
-    alignItems: 'center',
-    gap: 6,
-    ...CARD_SHADOW,
+  // Progress section action row (the "driving action" paired with each bar)
+  sectionActionBtn: {
+    alignItems: 'center', justifyContent: 'center', gap: 8,
+    paddingVertical: 12, borderRadius: radii.md,
   },
-  wayTileTxt: { fontSize: 14, fontFamily: 'PlexArabic-Bold', color: '#fff' },
-  wayBadge: { position: 'absolute', top: 8, paddingHorizontal: 7, paddingVertical: 2, borderRadius: radii.pill },
+  sectionActionTxt: { fontSize: 14, fontFamily: 'PlexArabic-Bold', color: '#fff' },
+  sectionBadge: { paddingHorizontal: 7, paddingVertical: 2, borderRadius: radii.pill },
   wayBadgeTxt: { fontSize: 10, fontFamily: 'PlexArabic-Bold' },
   wayNudge: {
     alignItems: 'center', gap: 6, padding: 10, borderRadius: radii.md,

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -2516,6 +2516,20 @@
         }
       }
     },
+    "node_modules/@firebase/auth-compat/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
@@ -4881,6 +4895,29 @@
       "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/@react-native-firebase/app/node_modules/@react-native-async-storage/async-storage": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.1.1.tgz",
+      "integrity": "sha512-z+PnLz1n6ECKhgoHZHkfc+dijXZEyZnNFSajbtE0NEbsJhmX8x9GlOeiMQIKX2E4DUqPSgfIh4FYBv1M49KgPQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "idb": "8.0.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-native-firebase/app/node_modules/@react-native-async-storage/async-storage/node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@react-native-firebase/app/node_modules/firebase": {
       "version": "12.15.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.15.0.tgz",
@@ -5993,9 +6030,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6010,9 +6044,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6027,9 +6058,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6044,9 +6072,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6061,9 +6086,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6078,9 +6100,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6095,9 +6114,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6112,9 +6128,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6129,9 +6142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6146,9 +6156,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9994,6 +10001,20 @@
         }
       }
     },
+    "node_modules/firebase/node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -13545,9 +13566,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13567,9 +13585,6 @@
       "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13591,9 +13606,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13613,9 +13625,6 @@
       "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/www/src/components/JourneyMap.tsx
+++ b/www/src/components/JourneyMap.tsx
@@ -14,7 +14,7 @@ import Svg, { Polyline } from 'react-native-svg';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { Avatar } from './Avatar';
 import {
-  CITIES, JOURNEY_MAP_IMAGE_ASPECT, JOURNEY_VIEWPORT_ASPECT, cityName, type PvpCity,
+  CITIES, JOURNEY_MAP_IMAGE_ASPECT, JOURNEY_VIEWPORT_ASPECT, PVP_TIER_COLOR, cityName, type PvpCity,
 } from '../models/pvpTiers';
 import type { ThemeColors } from '../theme/tokens';
 
@@ -40,14 +40,6 @@ function panLeftPercentForCity(city: PvpCity): number {
   const centered = -(city.xFrac * ZOOM - 0.5) * 100;
   return Math.max(PAN_MIN, Math.min(PAN_MAX, centered));
 }
-
-const TIER_DOT_COLOR: Record<PvpCity['tier'], string> = {
-  bronze: '#B08D57',
-  silver: '#9AA5B1',
-  gold: '#D4AF37',
-  platinum: '#8FD3D9',
-  hafizGold: '#2E9E6D',
-};
 
 function pct(v: number): `${number}%` {
   return `${v}%`;
@@ -108,7 +100,7 @@ export default function JourneyMap({ currentIndex, avatarUri, colors }: Props) {
                 {
                   left: pct(c.xFrac * 100),
                   top: pct(c.yFrac * 100),
-                  backgroundColor: reached ? TIER_DOT_COLOR[c.tier] : colors.card,
+                  backgroundColor: reached ? PVP_TIER_COLOR[c.tier] : colors.card,
                   borderColor: c.index === currentIndex ? colors.gold : colors.line,
                   borderWidth: c.index === currentIndex ? 2.5 : 1.5,
                   opacity: reached ? 1 : 0.6,

--- a/www/src/models/pvpTiers.ts
+++ b/www/src/models/pvpTiers.ts
@@ -14,6 +14,17 @@ export type PvpTierId = 'bronze' | 'silver' | 'gold' | 'platinum' | 'hafizGold';
 export const CITIES_PER_TIER = 4;
 export const TIER_IDS: PvpTierId[] = ['bronze', 'silver', 'gold', 'platinum', 'hafizGold'];
 
+// Single source of truth for tier color — used by JourneyMap's city dots and
+// by the PvP progress bar on me.tsx, so the bar's fill always matches the
+// tier the player is actually in instead of a flat shared gold.
+export const PVP_TIER_COLOR: Record<PvpTierId, string> = {
+  bronze: '#B08D57',
+  silver: '#9AA5B1',
+  gold: '#D4AF37',
+  platinum: '#8FD3D9',
+  hafizGold: '#2E9E6D',
+};
+
 // Points required to advance one city *within* each tier (index-aligned with
 // TIER_IDS) — a gentle ramp so Hafiz Gold cities are a bigger ask than Bronze ones.
 const TIER_STEP_COST: Record<PvpTierId, number> = {


### PR DESCRIPTION
## Summary
- The study-rank and PvP-journey progress cards on `me.tsx` sat stacked back-to-back with identical gold styling and near-identical "N points to next X" copy, which risks users reading them as the same/linked system — they're actually driven by unrelated actions (any correct quiz answer vs. PvP match wins only).
- Each bar now lives in its own labeled section with an explicit action button directly under it: "Start a Quiz" under study rank, "Live Competition" (start PvP) under the PvP journey — pairing each bar with the action that actually moves it.
- The PvP bar's fill now uses its current tier color (bronze/silver/gold/platinum/hafizGold) instead of the shared rank gold, reinforcing that it's a separate system. That tier→color map is now exported once from `src/models/pvpTiers.ts` (`PVP_TIER_COLOR`) and shared with `JourneyMap.tsx`'s city dots, replacing a duplicated local copy.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean (one pre-existing unrelated warning)
- [x] `CI=true npx jest --watchAll=false` — 227/227 tests pass, including `app/(app)/__tests__/me.test.tsx`
- [ ] Manual check in a running app (web/iOS/Android): tap each section's header to confirm it still opens the rank sheet / PvP journey screen, tap each action button to confirm it starts a quiz / PvP match, and confirm RTL (Arabic) layout looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)