### PR TITLE
Route push notification taps to their screen

### DIFF
--- a/www/app/_layout.tsx
+++ b/www/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Stack } from 'expo-router';
+import { Stack, useRouter, useRootNavigationState, type Href } from 'expo-router';
 import {
   I18nManager, ActivityIndicator, View, Text, TextInput, ImageBackground, Platform, StyleSheet,
 } from 'react-native';
@@ -11,7 +11,7 @@ import i18n from '../src/i18n';
 import { initDb } from '../src/db/initDb';
 import { initMadinaAssets } from '../src/services/madinaAssets';
 import { getFirebaseApp, flushPendingDailySubmit } from '../src/services/firebase';
-import { configureNotifications } from '../src/services/notifications';
+import { configureNotifications, observeNotificationTaps } from '../src/services/notifications';
 import { useProfileStore } from '../src/stores/profileStore';
 import { Analytics } from '../src/components/Analytics';
 import { ConsentBanner } from '../src/components/ConsentBanner';
@@ -138,6 +138,24 @@ const webStyles = StyleSheet.create({
   },
 });
 
+// Routes taps on server pushes (PvP challenges, friend requests) to their
+// screen — including the tap that cold-started the app. That launch tap can
+// only be acted on once the navigation tree under <Stack> exists (navigating
+// earlier throws), so this renders inside the ready branch below and
+// additionally waits for the root navigation state instead of running at
+// module scope like configureNotifications above. `navigate` (not `push`)
+// because the entry redirect may already have landed on /me — don't stack a
+// duplicate under the back button in that case.
+function NotificationTapRouter() {
+  const router = useRouter();
+  const navReady = Boolean(useRootNavigationState()?.key);
+  useEffect(() => {
+    if (!navReady) return;
+    return observeNotificationTaps((path) => router.navigate(path as Href));
+  }, [navReady, router]);
+  return null;
+}
+
 export default function RootLayout() {
   const [dbReady, setDbReady] = useState(false);
   const [dbProgress, setDbProgress] = useState(0);
@@ -210,6 +228,7 @@ export default function RootLayout() {
     <SafeAreaProvider>
       <StatusBar style="light" />
       <Analytics />
+      <NotificationTapRouter />
       <WebFrame>
         <I18nextProvider i18n={i18n}>
           <Stack screenOptions={{ headerShown: false }} />

--- a/www/src/services/__tests__/notifications.taps.test.ts
+++ b/www/src/services/__tests__/notifications.taps.test.ts
@@ -1,0 +1,118 @@
+// Tap-on-push routing (observeNotificationTaps / routeForNotification).
+//
+// expo-notifications reaches into native modules that aren't set up under
+// jest, so its API surface is mocked; jest-expo runs with Platform.OS='ios',
+// which makes the service's isNative guard pass. NOTE: handledTapId in the
+// service is module-level state shared by every test in this file — each test
+// uses distinct notification identifiers so the dedupe guard never carries
+// over between tests.
+
+const mockGetLastResponse = jest.fn<Promise<unknown>, []>();
+const mockAddListener = jest.fn();
+
+jest.mock('expo-notifications', () => ({
+  getLastNotificationResponseAsync: () => mockGetLastResponse(),
+  addNotificationResponseReceivedListener: (cb: unknown) => mockAddListener(cb),
+  // Surface touched by the rest of the service if anything else runs.
+  setNotificationHandler: jest.fn(),
+  setNotificationChannelAsync: jest.fn(() => Promise.resolve()),
+  AndroidImportance: { DEFAULT: 3 },
+  SchedulableTriggerInputTypes: { DATE: 'date' },
+}));
+
+// Keep the service's heavyweight imports out of the test environment.
+jest.mock('../firebase', () => ({ savePushToken: jest.fn() }));
+jest.mock('../../i18n', () => ({ __esModule: true, default: { t: (k: string) => k } }));
+
+import { observeNotificationTaps, routeForNotification } from '../notifications';
+
+type TapResponse = {
+  notification: { request: { identifier: string; content: { data: unknown } } };
+};
+
+function tap(identifier: string, data: unknown): TapResponse {
+  return { notification: { request: { identifier, content: { data } } } };
+}
+
+// One microtask hop is not enough: handle() runs inside the promise's .then.
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+let removeSub: jest.Mock;
+
+beforeEach(() => {
+  mockGetLastResponse.mockReset().mockResolvedValue(null);
+  removeSub = jest.fn();
+  mockAddListener.mockReset().mockReturnValue({ remove: removeSub });
+});
+
+describe('routeForNotification', () => {
+  it('maps the payload types functions/push.js sends to their screens', () => {
+    expect(routeForNotification({ type: 'pvp_invite', fromUid: 'x' })).toBe('/(app)/me');
+    expect(routeForNotification({ type: 'friend_request' })).toBe('/(app)/friends');
+  });
+
+  it('returns null for unknown or missing payloads', () => {
+    expect(routeForNotification({ type: 'someday_new_type' })).toBeNull();
+    expect(routeForNotification({})).toBeNull();
+    expect(routeForNotification(null)).toBeNull();
+    expect(routeForNotification(undefined)).toBeNull();
+    expect(routeForNotification('pvp_invite')).toBeNull();
+  });
+});
+
+describe('observeNotificationTaps', () => {
+  it('navigates for the cold-start tap that launched the app', async () => {
+    mockGetLastResponse.mockResolvedValue(tap('cold-1', { type: 'pvp_invite', fromUid: 'abc' }));
+    const navigate = jest.fn();
+    observeNotificationTaps(navigate);
+    await flush();
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/(app)/me');
+  });
+
+  it('navigates for taps received while the app is running', async () => {
+    const navigate = jest.fn();
+    observeNotificationTaps(navigate);
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as (r: TapResponse) => void;
+    listener(tap('warm-1', { type: 'friend_request' }));
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('/(app)/friends');
+  });
+
+  it('never navigates twice for the same tap (launch tap replayed via the listener)', async () => {
+    const launch = tap('dupe-1', { type: 'pvp_invite' });
+    mockGetLastResponse.mockResolvedValue(launch);
+    const navigate = jest.fn();
+    observeNotificationTaps(navigate);
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as (r: TapResponse) => void;
+    listener(launch);
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores payloads it has no route for', async () => {
+    mockGetLastResponse.mockResolvedValue(tap('odd-1', { type: 'mystery' }));
+    const navigate = jest.fn();
+    observeNotificationTaps(navigate);
+    await flush();
+    const listener = mockAddListener.mock.calls[0][0] as (r: TapResponse) => void;
+    listener(tap('odd-2', undefined));
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('stops routing after unsubscribe, even for an in-flight launch response', async () => {
+    let resolveLast!: (r: TapResponse) => void;
+    mockGetLastResponse.mockReturnValue(new Promise((res) => { resolveLast = res; }));
+    const navigate = jest.fn();
+    const unsub = observeNotificationTaps(navigate);
+    unsub();
+    expect(removeSub).toHaveBeenCalledTimes(1);
+    resolveLast(tap('late-1', { type: 'pvp_invite' }));
+    await flush();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/www/src/services/notifications.ts
+++ b/www/src/services/notifications.ts
@@ -153,3 +153,52 @@ export async function registerPushToken(uid: string): Promise<void> {
   }
 }
 
+/**
+ * Map a server push's data payload (attached in functions/push.js) to the
+ * in-app path a tap on it should open. PvP invites only need to land inside
+ * the (app) group: its layout watches /pvp/invites globally and pops the
+ * accept/decline modal on its own, so home is the right destination.
+ */
+export function routeForNotification(data: unknown): string | null {
+  const type = (data as { type?: unknown } | null | undefined)?.type;
+  switch (type) {
+    case 'pvp_invite':
+      return '/(app)/me';
+    case 'friend_request':
+      return '/(app)/friends';
+    default:
+      return null;
+  }
+}
+
+// Module-level so it survives an observer remount: the same tap must never
+// navigate twice — getLastNotificationResponseAsync keeps returning the launch
+// tap for the whole process lifetime, and Android can additionally replay it
+// through the response listener.
+let handledTapId: string | null = null;
+
+/**
+ * Route notification taps to their screen: the cold-start tap that launched
+ * the process (last response) plus taps while the app is running. Call once
+ * the navigation tree is mounted. Returns an unsubscribe fn. No-op on web.
+ */
+export function observeNotificationTaps(navigate: (path: string) => void): () => void {
+  if (!isNative) return () => {};
+  let disposed = false;
+  const handle = (response: Notifications.NotificationResponse | null) => {
+    if (disposed || !response) return;
+    const id = response.notification.request.identifier;
+    if (id && id === handledTapId) return;
+    const route = routeForNotification(response.notification.request.content.data);
+    if (!route) return;
+    handledTapId = id;
+    navigate(route);
+  };
+  Notifications.getLastNotificationResponseAsync().then(handle).catch(() => { /* best-effort */ });
+  const sub = Notifications.addNotificationResponseReceivedListener(handle);
+  return () => {
+    disposed = true;
+    sub.remove();
+  };
+}
+


### PR DESCRIPTION
## What

Tapping a challenge (or friend-request) push notification now takes the user to the right place instead of just opening the app wherever it last was. The server side (`onpvpinvite` / `onfriendrequest` → `sendPush`) already attached a `{type}` data payload; this adds the missing client half.

- **`pvp_invite` → `/(app)/me`** — the `(app)` layout already watches `/pvp/invites` globally and pops the accept/decline modal on its own, so landing inside the app group is all that's needed.
- **`friend_request` → `/(app)/friends`** — where the pending-requests list lives.

## How

- `routeForNotification(data)` — pure payload→path mapping (exported for tests).
- `observeNotificationTaps(navigate)` — handles both warm taps (`addNotificationResponseReceivedListener`) and the cold-start tap that launched the process (`getLastNotificationResponseAsync`), with a module-level guard so the same tap never navigates twice (the launch response persists for the whole process lifetime, and Android can replay it through the listener). No-op on web, like the rest of the notifications service.
- `NotificationTapRouter` in the root layout — mounts next to `<Stack>` in the ready branch and waits for `useRootNavigationState().key`, since navigating before the tree exists throws. Uses `router.navigate` (not `push`) so the entry redirect's `/me` isn't duplicated under the back button.
- Signed-out cold starts need nothing new: navigating into `(app)` while logged out already rides the existing `pendingDeepLink` bounce through `(auth)` and back.

## Tests

7 new tests in `notifications.taps.test.ts`: payload mapping (known/unknown/malformed), cold-start tap, warm tap, launch-tap replay dedupe, no-route payloads, and unsubscribe cancelling an in-flight launch response. Full suite: 31 suites / 317 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)