### PR TITLE
Make the monthly leaderboard cumulative per user

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,12 @@ npx expo export --clear               # ALWAYS pass --clear on a version bump,
 # Type check
 npx tsc --noEmit
 
-# Tests (Jest)
-npm test
+# Tests (Jest) — use test:ci for a single run; plain `npm test` is watch mode
+# (--watchAll) and never exits
+npm run test:ci
+
+# Cloud Functions tests (node --test, run from functions/)
+cd ../functions && npm test
 
 # Deploy hosting (after expo export)
 firebase deploy --only hosting

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ const { onValueCreated } = require('firebase-functions/v2/database');
 const logger = require('firebase-functions/logger');
 const { sendPush, isCategoryEnabled } = require('./push.js');
 const { streaksched } = require('./streak.js');
+const { mergeDayIntoMonthTotals, topOfMonth } = require('./monthTotals.js');
 exports.streaksched = streaksched;
 
 // The Firebase Admin SDK to access the Realtime Database.
@@ -68,33 +69,34 @@ exports.weeklysched = onSchedule('every 168 hours', async () => {
 });
 
 function dailyQuiz() {
-  return admin.database().ref('daily/head_submit').orderByChild('score').limitToLast(5).once('value')
-    .then(async function (top5) {
-      // Get Top-5 of Today's Quiz
-      var yesterday = [];
-      top5.forEach(function (t) {
-        yesterday.push(t.val());
-      });
-      yesterday.reverse();
-      // Store them in Yesterday
-      if (yesterday.length > 0) {
+  // Full day's submissions, not a top-5 query: the monthly board is cumulative
+  // per uid, so every participant's score counts — the consistent mid-field
+  // player is exactly who the old top-5-only merge kept invisible.
+  return admin.database().ref('daily/head_submit').once('value')
+    .then(async function (subsSnap) {
+      var submissions = Object.values(subsSnap.val() || {});
+      if (submissions.length > 0) {
+        // Yesterday's report stays a best-first top-5 of single-day scores.
+        var yesterday = submissions.slice().sort(function (a, b) {
+          return (b.score || 0) - (a.score || 0);
+        }).slice(0, 5);
         await admin.database().ref('daily/reports/yday').set(yesterday);
 
-        // Merge into this calendar month's leaderboard. Resets automatically
-        // on the first run of a new month: the stored month key won't match,
-        // so the old accumulated entries are dropped instead of carried over.
+        // Merge everyone into this month's cumulative per-uid totals. Resets
+        // automatically on the first run of a new month: the stored month key
+        // won't match, so old totals are dropped instead of carried over.
         var monthKey = new Date().toISOString().slice(0, 7); // "YYYY-MM"
         var storedMonth = await admin.database().ref('daily/reports/month_key').once('value');
-        var arr_old = [];
+        var totals = {};
         if (storedMonth.val() === monthKey) {
-          var old = await admin.database().ref('daily/reports/month').once('value');
-          arr_old = old.val() || [];
+          var old = await admin.database().ref('daily/reports/month_totals').once('value');
+          totals = old.val() || {};
         }
-        var oldPlusYesterday = arr_old.concat(yesterday);
-        oldPlusYesterday.sort(function (a, b) {
-          return (a.score > b.score) ? -1 : ((b.score > a.score) ? 1 : 0);
-        });
-        await admin.database().ref('daily/reports/month').set(oldPlusYesterday.slice(0, 10));
+        totals = mergeDayIntoMonthTotals(totals, submissions);
+        await admin.database().ref('daily/reports/month_totals').set(totals);
+        // Legacy mirror: shipped clients read a top-10 array at reports/month;
+        // they get the same cumulative standings, just without own-rank/days.
+        await admin.database().ref('daily/reports/month').set(topOfMonth(totals, 10));
         await admin.database().ref('daily/reports/month_key').set(monthKey);
       }
 

--- a/functions/monthTotals.js
+++ b/functions/monthTotals.js
@@ -1,0 +1,52 @@
+// Cumulative monthly leaderboard aggregation. Pure functions (no admin SDK)
+// so the daily cron's merge logic is unit-testable with `npm test`.
+
+/**
+ * Merge one day's raw submissions into the per-uid cumulative month totals.
+ *
+ * Submissions are push()-keyed, so nothing server-side stops a client from
+ * submitting twice in a day — dedupe to one score per uid (best wins) before
+ * adding, or duplicates would inflate the running total.
+ *
+ * @param {Object|null} totals  current map: uid -> {uid, name, score, days, country?}
+ * @param {Array} daySubmissions  one day's entries: {uid, name, score, country?}
+ * @returns {Object} new totals map (input is not mutated)
+ */
+function mergeDayIntoMonthTotals(totals, daySubmissions) {
+  const bestOfDay = new Map();
+  for (const sub of daySubmissions || []) {
+    if (!sub || typeof sub.uid !== 'string' || !sub.uid) continue;
+    if (typeof sub.score !== 'number' || !isFinite(sub.score)) continue;
+    const prev = bestOfDay.get(sub.uid);
+    if (!prev || sub.score > prev.score) bestOfDay.set(sub.uid, sub);
+  }
+
+  const next = Object.assign({}, totals);
+  for (const [uid, sub] of bestOfDay) {
+    const cur = next[uid];
+    // Scores can be fractional (speed bonus) — round the running sum to 2
+    // decimals so float noise never accumulates into the displayed total.
+    const entry = {
+      uid: uid,
+      name: sub.name || (cur && cur.name) || '',
+      score: Math.round(((cur ? cur.score : 0) + sub.score) * 100) / 100,
+      days: (cur ? cur.days : 0) + 1,
+    };
+    const country = sub.country || (cur && cur.country);
+    if (country) entry.country = country;
+    next[uid] = entry;
+  }
+  return next;
+}
+
+/**
+ * Best-first top-N slice of the totals map, in the legacy array shape old
+ * clients read from daily/reports/month.
+ */
+function topOfMonth(totals, n) {
+  return Object.values(totals || {})
+    .sort((a, b) => (b.score || 0) - (a.score || 0))
+    .slice(0, n);
+}
+
+module.exports = { mergeDayIntoMonthTotals, topOfMonth };

--- a/functions/monthTotals.test.js
+++ b/functions/monthTotals.test.js
@@ -1,0 +1,84 @@
+// Run with `npm test` (node --test — no test framework dependency).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { mergeDayIntoMonthTotals, topOfMonth } = require('./monthTotals.js');
+
+test('starts totals from an empty/null map', () => {
+  const totals = mergeDayIntoMonthTotals(null, [
+    { uid: 'a', name: 'Ali', score: 10, country: 'EG' },
+  ]);
+  assert.deepEqual(totals, {
+    a: { uid: 'a', name: 'Ali', score: 10, days: 1, country: 'EG' },
+  });
+});
+
+test('accumulates score and days across days', () => {
+  let totals = mergeDayIntoMonthTotals(null, [{ uid: 'a', name: 'Ali', score: 10 }]);
+  totals = mergeDayIntoMonthTotals(totals, [{ uid: 'a', name: 'Ali', score: 7.5 }]);
+  totals = mergeDayIntoMonthTotals(totals, [{ uid: 'a', name: 'Ali', score: 2 }]);
+  assert.equal(totals.a.score, 19.5);
+  assert.equal(totals.a.days, 3);
+});
+
+test('dedupes within a day: best score counts once', () => {
+  const totals = mergeDayIntoMonthTotals(null, [
+    { uid: 'a', name: 'Ali', score: 4 },
+    { uid: 'a', name: 'Ali', score: 9 },
+    { uid: 'a', name: 'Ali', score: 6 },
+  ]);
+  assert.equal(totals.a.score, 9);
+  assert.equal(totals.a.days, 1);
+});
+
+test('skips malformed entries (missing uid or non-numeric score)', () => {
+  const totals = mergeDayIntoMonthTotals(null, [
+    { name: 'NoUid', score: 5 },
+    { uid: 'b', name: 'BadScore', score: 'high' },
+    { uid: 'c', name: 'NaN', score: NaN },
+    null,
+    { uid: 'd', name: 'Ok', score: 3 },
+  ]);
+  assert.deepEqual(Object.keys(totals), ['d']);
+});
+
+test('keeps the latest name and backfills country both ways', () => {
+  let totals = mergeDayIntoMonthTotals(null, [{ uid: 'a', name: 'Old', score: 1, country: 'EG' }]);
+  // Renamed, no country today: name updates, stored country survives.
+  totals = mergeDayIntoMonthTotals(totals, [{ uid: 'a', name: 'New', score: 1 }]);
+  assert.equal(totals.a.name, 'New');
+  assert.equal(totals.a.country, 'EG');
+  // Country appearing later fills a total that had none.
+  let t2 = mergeDayIntoMonthTotals(null, [{ uid: 'b', name: 'B', score: 1 }]);
+  t2 = mergeDayIntoMonthTotals(t2, [{ uid: 'b', name: 'B', score: 1, country: 'MA' }]);
+  assert.equal(t2.b.country, 'MA');
+});
+
+test('rounds running float sums to 2 decimals', () => {
+  let totals = null;
+  for (let i = 0; i < 10; i++) {
+    totals = mergeDayIntoMonthTotals(totals, [{ uid: 'a', name: 'A', score: 0.1 }]);
+  }
+  assert.equal(totals.a.score, 1);
+});
+
+test('does not mutate the input totals map', () => {
+  const before = { a: { uid: 'a', name: 'A', score: 5, days: 1 } };
+  const frozen = JSON.parse(JSON.stringify(before));
+  mergeDayIntoMonthTotals(before, [{ uid: 'a', name: 'A', score: 5 }]);
+  assert.deepEqual(before, frozen);
+});
+
+test('topOfMonth sorts best-first and slices to n', () => {
+  const totals = {
+    a: { uid: 'a', name: 'A', score: 5, days: 2 },
+    b: { uid: 'b', name: 'B', score: 12, days: 4 },
+    c: { uid: 'c', name: 'C', score: 8, days: 1 },
+  };
+  const top2 = topOfMonth(totals, 2);
+  assert.deepEqual(top2.map((e) => e.uid), ['b', 'c']);
+});
+
+test('topOfMonth tolerates an empty map', () => {
+  assert.deepEqual(topOfMonth(null, 10), []);
+  assert.deepEqual(topOfMonth({}, 10), []);
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,6 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
+    "test": "node --test",
     "serve": "firebase serve --only functions",
     "shell": "firebase experimental:functions:shell",
     "start": "npm run shell",

--- a/www/app/(app)/league.tsx
+++ b/www/app/(app)/league.tsx
@@ -48,7 +48,10 @@ export default function LeagueScreen() {
   const [status, setStatus] = useState<Status>('loading');
   const [head, setHead] = useState<DailyHead | null>(null);
   const [yday, setYday] = useState<LeaderboardEntry[]>([]);
-  const [monthTop, setMonthTop] = useState<LeaderboardEntry[]>([]);
+  // Full month standings (cumulative per-uid totals, best-first, unbounded) —
+  // kept whole so the user's own monthly rank is computable even when they're
+  // far outside the top-10 slice the list displays.
+  const [monthAll, setMonthAll] = useState<LeaderboardEntry[]>([]);
   const [ydayLoaded, setYdayLoaded] = useState(false);
   const [monthLoaded, setMonthLoaded] = useState(false);
   // Today's live, unbounded standings (every submission so far today) — the
@@ -87,7 +90,7 @@ export default function LeagueScreen() {
       setYdayLoaded(true);
     }).then((unsub) => { if (cancelled) unsub(); else unsubYday = unsub; });
     const unsubMonth = subscribeMonthlyTopReport((entries) => {
-      setMonthTop(entries.slice(0, 10));
+      setMonthAll(entries);
       setMonthLoaded(true);
     });
     const unsubToday = subscribeTodayStandings(setTodayStandings);
@@ -127,9 +130,12 @@ export default function LeagueScreen() {
     ]);
   }
 
-  const listData = tab === 'today' ? todayStandings : tab === 'yesterday' ? yday : monthTop;
+  const listData = tab === 'today' ? todayStandings : tab === 'yesterday' ? yday : monthAll.slice(0, 10);
   const reportsLoading = tab === 'today' ? false : tab === 'yesterday' ? !ydayLoaded : !monthLoaded;
   const ownRank = findOwnRank(todayStandings, profile.uid);
+  // Own monthly rank — only rendered as an extra tail row when the user is
+  // outside the displayed top-10 (inside it, their own row is already lit up).
+  const monthOwnRank = tab === 'month' ? findOwnRank(monthAll, profile.uid, 0) : null;
 
   // Movement vs yesterday — only computable where we have real data: the
   // اليوم tab, cross-referenced against yesterday's own top-N report. Rows
@@ -151,6 +157,19 @@ export default function LeagueScreen() {
   const podium = listData.length >= 3 ? listData.slice(0, 3) : [];
   const rest = listData.length >= 3 ? listData.slice(3) : listData;
 
+  // Days-played chip for cumulative month rows: calendar icon + localized
+  // count. Language-neutral on purpose — no pluralized string to translate
+  // into every locale. Renders nothing for single-day entries (no days field).
+  function daysChipFor(item: LeaderboardEntry) {
+    if (item.days == null) return null;
+    return (
+      <View style={[s.daysChip, { flexDirection: rowDir(isRTL) }]}>
+        <Ionicons name="calendar-clear-outline" size={11} color={colors.inkSoft} />
+        <Text style={[s.daysChipTxt, { color: colors.inkSoft }]}>{localeNum(item.days, language)}</Text>
+      </View>
+    );
+  }
+
   function renderRow({ item, index }: { item: LeaderboardEntry; index: number }) {
     const rank = index + podium.length + 1; // podium (if any) covers 1..podium.length
     const isMe = item.uid === profile.uid;
@@ -161,6 +180,7 @@ export default function LeagueScreen() {
         <Text style={[s.rank, { color: colors.inkSoft }]}>{localeNum(rank, language)}</Text>
         {flag ? <Text style={s.rowFlag}>{flag}</Text> : <View style={s.rowFlagPlaceholder} />}
         <Text style={[s.rowName, { color: colors.ink, textAlign: alignDir(isRTL) }, isMe && { fontFamily: 'PlexArabic-Bold', color: colors.goldDeep }]} numberOfLines={1}>{item.name ?? t('common.guestName')}</Text>
+        {daysChipFor(item)}
         {delta != null && delta !== 0 && (
           <Text style={[s.delta, delta > 0 ? { color: colors.correct } : { color: colors.wrong }]}>
             {delta > 0 ? `▲${localeNum(delta, language)}` : `▼${localeNum(Math.abs(delta), language)}`}
@@ -180,6 +200,7 @@ export default function LeagueScreen() {
         <Text style={[s.rank, { color: colors.inkSoft }]}>{item.rank <= 3 ? MEDAL[item.rank - 1] : localeNum(item.rank, language)}</Text>
         {flag ? <Text style={s.rowFlag}>{flag}</Text> : <View style={s.rowFlagPlaceholder} />}
         <Text style={[s.rowName, { color: colors.ink, textAlign: alignDir(isRTL) }, isMe && { fontFamily: 'PlexArabic-Bold', color: colors.goldDeep }]} numberOfLines={1}>{item.name ?? t('common.guestName')}</Text>
+        {daysChipFor(item)}
         <Text style={[s.rowScore, { color: colors.ink, textAlign: isRTL ? 'left' : 'right' }, isMe && { color: colors.goldDeep }]}>{localeNum(item.score, language)}</Text>
       </View>
     );
@@ -301,6 +322,14 @@ export default function LeagueScreen() {
                   {renderRow({ item, index })}
                 </Fragment>
               ))}
+              {/* Your own monthly standing when it falls below the top-10 —
+                  the cumulative feed is unbounded, so the real rank is known. */}
+              {monthOwnRank && monthOwnRank.rank > listData.length && (
+                <>
+                  <Text style={[s.moreDots, { color: colors.inkSoft }]}>⋯</Text>
+                  {renderNeighborRow(monthOwnRank.entry, true)}
+                </>
+              )}
             </>
           )}
         </View>
@@ -373,6 +402,9 @@ const s = StyleSheet.create({
   rowFlag: { fontSize: 18, width: 28, textAlign: 'center' },
   rowFlagPlaceholder: { width: 28 },
   rowName: { flex: 1, fontSize: 14 },
+  daysChip: { alignItems: 'center', gap: 3 },
+  daysChipTxt: { fontSize: 11, fontFamily: 'PlexArabic-SemiBold' },
+  moreDots: { textAlign: 'center', fontSize: 16, lineHeight: 16, marginTop: 2 },
   delta: { fontSize: 11, fontFamily: 'PlexArabic-Bold' },
   rowScore: { fontSize: 15, fontFamily: 'PlexArabic-Bold', minWidth: 42 },
   sep: { height: 1, marginHorizontal: 14 },

--- a/www/src/services/firebase.ts
+++ b/www/src/services/firebase.ts
@@ -546,7 +546,7 @@ export async function getMonthlyTopReport(): Promise<unknown[]> {
   }
 }
 
-export interface LeaderboardEntry { name?: string; score: number; uid?: string; country?: string }
+export interface LeaderboardEntry { name?: string; score: number; uid?: string; country?: string; days?: number }
 
 /**
  * Live top-10-of-yesterday feed (was a one-time getYesterdayReport() read).
@@ -566,11 +566,28 @@ export async function subscribeYesterdayReport(
   );
 }
 
-/** Live top-10-of-this-month feed (was a one-time getMonthlyTopReport() read). */
+/**
+ * Live this-month standings: cumulative per-uid totals (score summed over the
+ * user's best daily submission each day, plus a days-played count), sorted
+ * best-first and unbounded — full coverage, so own-rank works like اليوم.
+ * Falls back to the legacy top-10 array at reports/month when the totals node
+ * doesn't exist yet (the first post-deploy cron run hasn't happened).
+ */
 export function subscribeMonthlyTopReport(cb: (entries: LeaderboardEntry[]) => void): () => void {
   return onValue(
-    ref(getFirebaseDb(), '/daily/reports/month'),
-    (snap) => cb((snap.val() as LeaderboardEntry[]) ?? []),
+    ref(getFirebaseDb(), '/daily/reports/month_totals'),
+    (snap) => {
+      const val = snap.val() as Record<string, LeaderboardEntry> | null;
+      if (val) {
+        const list = Object.values(val);
+        list.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+        cb(list);
+        return;
+      }
+      dbGet(ref(getFirebaseDb(), '/daily/reports/month'))
+        .then((legacy) => cb((legacy.val() as LeaderboardEntry[]) ?? []))
+        .catch(() => cb([]));
+    },
     () => cb([]),
   );
 }


### PR DESCRIPTION
## What

The month tab of the league screen previously showed the 10 best *single-day* scores of the month — only day-top-5 finishers ever fed into it, and one user could occupy several rows. It now ranks users by their **cumulative total**: each day's best submission per uid is summed across the month, with a days-played count.

## Why

- A player who finishes 6th every single day contributed more than anyone but never appeared on the monthly board at all.
- Rewarding consistent daily review fits the app's purpose better than rewarding one strong day (the yesterday tab still honors peak performance).
- Cumulative totals give the board daily movement.

## How

**Backend** (`functions/`)
- `dailyQuiz()` now reads the *full* day's submissions instead of a top-5 query. Yesterday's top-5 report is unchanged.
- New `monthTotals.js`: pure merge logic — per-uid dedupe within the day (submissions are `push()`-keyed, so nothing server-side prevented double submission; best score wins), cumulative sum + days count, 2-decimal rounding, latest name wins, country backfill.
- Totals live at `daily/reports/month_totals` (per-uid map). A top-10 array in the old shape is still mirrored to `daily/reports/month`, so already-shipped clients keep working and simply show cumulative standings.
- Month rollover logic (`month_key`) unchanged. No RTDB rules change needed — `daily/reports` has a parent-level authenticated read.
- Tests: `functions/monthTotals.test.js` via dependency-free `node --test` (new `npm test` script in functions/).

**Client** (`www/`)
- `subscribeMonthlyTopReport` reads the unbounded totals map, sorted best-first, falling back to the legacy array until the first post-deploy cron run.
- Month tab rows show a calendar-icon + localized-number days chip — deliberately language-neutral, so no new strings across the 16 locales.
- When the user is ranked outside the displayed top-10, their own ranked row is appended under a ⋯ separator (mirrors the today tab's own-rank affordance).
- `CLAUDE.md`: test command corrected to `npm run test:ci` (`npm test` is `--watchAll` and never exits) + functions test command.

## Verification

- `functions`: `npm test` — 9/9 pass; `node --check index.js` clean.
- `www`: `npx tsc --noEmit` clean; `npm run test:ci` — 310/310 pass (30 suites).

## Deploy notes

- Needs `firebase deploy --only functions` after merge (same gotcha as database rules — shipping the commit alone changes nothing).
- Until the first cron run after deploy, the month tab serves the legacy array via the fallback; totals start accumulating from that run onward. Merging early in August means a clean month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)